### PR TITLE
Implement Objection Models

### DIFF
--- a/api/codegen.yaml
+++ b/api/codegen.yaml
@@ -6,5 +6,13 @@ config:
 generates:
   ./generated/schema-types.ts: # Typescript types (output generated file)
     plugins: # List of needed plugins (installed as devDeps)
+      - add:
+          content: 'declare namespace API {'
+      - add:
+          placement: append
+          content: '}'
+      - add:
+          placement: append
+          content: 'export default API'
       - typescript
       - typescript-resolvers

--- a/api/generated/schema-types.ts
+++ b/api/generated/schema-types.ts
@@ -1,4 +1,5 @@
 import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
+declare namespace API {
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
@@ -187,3 +188,6 @@ export type Resolvers<ContextType = any> = {
   Query?: QueryResolvers<ContextType>;
 };
 
+
+}
+export default API

--- a/api/graphql/resolvers.ts
+++ b/api/graphql/resolvers.ts
@@ -1,17 +1,14 @@
 import { toCamel } from 'snake-camel'
 import knex from '../db'
-import type {
-	QueryMatterArgs,
-	Resolvers,
-	Matter,
-} from '../generated/schema-types'
-import { MatterStatus } from '../generated/schema-types'
 import { date } from './scalars'
+import type API from '../generated/schema-types'
 
-const resolvers: Resolvers = {
+const resolvers: API.Resolvers = {
 	Query: {
-		async matters(): Promise<Matter[]> {
-			const rows = await knex<Matter>('nyc_council_matters')
+		async matters(): Promise<API.Matter[]> {
+			// const row = await
+
+			const rows = await knex<API.Matter>('nyc_council_matters')
 				.select('*')
 				.select(
 					knex.raw(
@@ -29,10 +26,10 @@ const resolvers: Resolvers = {
 				throw new Error('failed to fetch rows')
 			}
 
-			return rows.map((r) => toCamel(r) as Matter)
+			return rows.map((r) => toCamel(r) as API.Matter)
 		},
-		async matter(_: {}, args: QueryMatterArgs): Promise<Matter> {
-			let matter = await knex<Matter>('nyc_council_matters')
+		async matter(_: {}, args: API.QueryMatterArgs): Promise<API.Matter> {
+			let matter = await knex<API.Matter>('nyc_council_matters')
 				.where({
 					id: args.id,
 				})
@@ -42,8 +39,8 @@ const resolvers: Resolvers = {
 				throw new Error(`matter ${args.id} not found`)
 			}
 
-			matter = toCamel(matter) as Matter
-			matter.status = matter.status.toUpperCase() as MatterStatus
+			matter = toCamel(matter) as API.Matter
+			matter.status = matter.status.toUpperCase() as API.MatterStatus
 
 			console.log(matter)
 
@@ -51,10 +48,10 @@ const resolvers: Resolvers = {
 		},
 	},
 	Matter: {
-		status(matter: Matter): MatterStatus {
-			return matter.status.toUpperCase() as MatterStatus
+		status(matter: API.Matter): API.MatterStatus {
+			return matter.status.toUpperCase() as API.MatterStatus
 		},
-		async postDate(matter: Matter): Promise<Date> {
+		async postDate(matter: API.Matter): Promise<Date> {
 			const dates: number[] = []
 
 			if (matter.passedAt) {


### PR DESCRIPTION
* Wrap generated GraphQL types with `API` namespace. All types will be referred to as `API.Matter` etc.
* Add [Objection](https://vincit.github.io/objection.js/) for models and support for strongly typed query results